### PR TITLE
Change limit from 64 MB to 50 MD according to Telegram Bot API docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "sharp": "^0.29.0",
     "typescript": "^4.3.5"
   },
-
   "_comment": "ECONOMY ~ 30MB IF SET UP ON PRODUCTION (yarn install --production))",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.28.1",

--- a/src/common/constants/photosToPdf.ts
+++ b/src/common/constants/photosToPdf.ts
@@ -1,4 +1,4 @@
-const MAX_MEGABYTES = 64
+const MAX_MEGABYTES = 50
 
-// 64 000 000 bytes = 64 MB
+// 50 000 000 bytes = 50 MB
 export const MAX_FILE_SUMMARY_SIZE = MAX_MEGABYTES * Math.pow(10, 6)

--- a/src/controllers/menus/photos-to-pdf/index.ts
+++ b/src/controllers/menus/photos-to-pdf/index.ts
@@ -23,7 +23,7 @@ export async function showPhotosToPdfConvertMenu(chatId: number): Promise<Messag
 }
 
 export async function showSizeLimitExceededMessage(chatId: number): Promise<Message> {
-    return await bot.sendMessage(chatId, '‼ Превышен предел суммарной памяти фотографий для конвертации (64 МБ)')
+    return await bot.sendMessage(chatId, '‼ Превышен предел суммарной памяти фотографий для конвертации (50 МБ)')
 }
 
 export async function showUnknownPhotoSizeMessage(chatId: number): Promise<Message> {


### PR DESCRIPTION
Change limit from 64 MB to 50 MD according to Telegram Bot API documentation